### PR TITLE
uci-defaults network interfaces from ifname to device

### DIFF
--- a/lede/futel.defaults-airrouter
+++ b/lede/futel.defaults-airrouter
@@ -9,7 +9,7 @@ delete network.globals
 
 set network.wan=interface
 set network.wan.proto=dhcp
-set network.wan.ifname=eth1
+set network.wan.device=eth1
 set network.wan.dns="8.8.8.8 8.8.4.4"
 
 set network.wan6=interface

--- a/lede/futel.defaults-ar750
+++ b/lede/futel.defaults-ar750
@@ -12,12 +12,12 @@ set network.wan.proto=dhcp
 set network.wan.dns="8.8.8.8 8.8.4.4"
 
 set network.wan6=interface
-set network.wan6.ifname='@wan'
+set network.wan6.device='@wan'
 set network.wan6.proto='dhcpv6'
 set network.wan6.reqprefix='60'
 
 set network.vpn=interface
-set network.vpn.ifname=tun0
+set network.vpn.device=tun0
 set network.vpn.proto=none
 
 commit network

--- a/lede/futel.defaults-ar750-wifi
+++ b/lede/futel.defaults-ar750-wifi
@@ -9,16 +9,16 @@ delete network.globals
 
 set network.wan=interface
 set network.wan.proto=dhcp
-set network.wan.ifname=""
+set network.wan.device=""
 set network.wan.dns="8.8.8.8 8.8.4.4"
 
 set network.wan6=interface
-set network.wan6.ifname='@wan'
+set network.wan6.device='@wan'
 set network.wan6.proto='dhcpv6'
 set network.wan6.reqprefix='60'
 
 set network.vpn=interface
-set network.vpn.ifname=tun0
+set network.vpn.device=tun0
 set network.vpn.proto=none
 
 commit network

--- a/lede/futel.defaults-mt300n-v2
+++ b/lede/futel.defaults-mt300n-v2
@@ -12,12 +12,12 @@ set network.wan.proto=dhcp
 set network.wan.dns="8.8.8.8 8.8.4.4"
 
 set network.wan6=interface
-set network.wan6.ifname='@wan'
+set network.wan6.device='@wan'
 set network.wan6.proto='dhcpv6'
 set network.wan6.reqprefix='60'
 
 set network.vpn=interface
-set network.vpn.ifname=tun0
+set network.vpn.device=tun0
 set network.vpn.proto=none
 
 commit network

--- a/lede/futel.defaults-mt300n-v2-usb
+++ b/lede/futel.defaults-mt300n-v2-usb
@@ -13,12 +13,12 @@ set network.wan.proto=dhcp
 set network.wan.dns="8.8.8.8 8.8.4.4"
 
 set network.wan6=interface
-set network.wan6.ifname='@wan'
+set network.wan6.device='@wan'
 set network.wan6.proto='dhcpv6'
 set network.wan6.reqprefix='60'
 
 set network.vpn=interface
-set network.vpn.ifname=tun0
+set network.vpn.device=tun0
 set network.vpn.proto=none
 
 commit network

--- a/lede/futel.defaults-wgt634u
+++ b/lede/futel.defaults-wgt634u
@@ -12,12 +12,12 @@ set network.wan.proto=dhcp
 set network.wan.dns="8.8.8.8 8.8.4.4"
 
 set network.wan6=interface
-set network.wan6.ifname='@wan'
+set network.wan6.device='@wan'
 set network.wan6.proto='dhcpv6'
 set network.wan6.reqprefix='60'
 
 set network.vpn=interface
-set network.vpn.ifname=tun0
+set network.vpn.device=tun0
 set network.vpn.proto=none
 
 commit network

--- a/lede/futel.defaults-wgt634u-wifi
+++ b/lede/futel.defaults-wgt634u-wifi
@@ -9,16 +9,16 @@ delete network.globals
 
 set network.wan=interface
 set network.wan.proto=dhcp
-set network.wan.ifname=""
+set network.wan.device=""
 set network.wan.dns="8.8.8.8 8.8.4.4"
 
 set network.wan6=interface
-set network.wan6.ifname='@wan'
+set network.wan6.device='@wan'
 set network.wan6.proto='dhcpv6'
 set network.wan6.reqprefix='60'
 
 set network.vpn=interface
-set network.vpn.ifname=tun0
+set network.vpn.device=tun0
 set network.vpn.proto=none
 
 commit network


### PR DESCRIPTION
This is untested, but is what I'd expect to work for modern OpenWrt, making the changes to network interface devices instead of ifnames.

Signed-off-by: Russell Senior <russell@personaltelco.net>